### PR TITLE
Account For Header That May Not Be Present

### DIFF
--- a/routes/card_search.py
+++ b/routes/card_search.py
@@ -4,6 +4,7 @@ from flask import (
     request,
     redirect,
     session,
+    url_for,
     g,
 )
 
@@ -72,6 +73,10 @@ def view_search_results(num):
     api = API()
     card_list = api.get_search_results(params, num)
     headers = card_list.headers
+    total_count = headers.get("Total-Count")
+    if not total_count:
+        return redirect(url_for("home"))
+
     pages = math.ceil(int(headers["Total-Count"]) / 100)
     if g.user:
         user = User.query.get_or_404(g.user.id)

--- a/tests/test_card_search.py
+++ b/tests/test_card_search.py
@@ -1,0 +1,38 @@
+from unittest import TestCase
+
+from app import app
+
+
+app.config['WTF_CSRF_ENABLED'] = False
+
+
+class TestCardSearch(TestCase):
+    def test_redirect_on_bad_data_entry_to_card_search(self):
+        """
+           Test that the user is redirected to the home
+           page if they enter bad data into the search form,
+           which would cause the mtg api to return no results.
+
+           The data below is not valid, and will cause the mtg api
+           to return a result with no "Total-Count" header.
+        """
+        with app.test_client() as client:
+            with client.session_transaction() as sess:
+                # Setting these, as they are set in "card_search_function()"
+                # in routes/card_search.py
+                sess["dict"] = {
+                    "name": "gknsdfkdsf", 
+                    "power": "sfgkfsngskgsngskgs", 
+                    "rarity": "Common", 
+                    "setName": "sgksnfssgsgsg", 
+                    "toughness": "sgskngsgksgnsgsgsgsgsgs"
+                }
+
+            response = client.get("/cs/search-results/page1", follow_redirects=True)
+            html = response.get_data(as_text=True)
+
+            # Indicates a successful response and the presence
+            # of the search button, which is present on the home page.
+            self.assertIn("card-search-button", html)
+            self.assertEqual(response.status_code, 200)
+            


### PR DESCRIPTION
## Summary

This PR is being made to address the fact that if someone was to enter "nonsense" into the card search form and submit it, the MTG API would not return a successful response with a 200 status code; it would return a `400 Bad Request` response instead. This response would have no `"Total-Count"` header, causing the app to crash.

The fix here was to:
1. Use the `.get()` method to access dictionary keys when we are not 100% certain that they are there. If they are not there, it will return `None` ( unless you give it a default value such as `headers.get("Total-Count", 2000)` ).
2. We do a check to see if the `"Total-Count"` header exists via `if not total_count:`.
3. If it does not exist, we redirect to the home page so that the user can search again. Note that you could use Flask's `flash` to show a message as to why they are being redirected if desired.

## Testing Done
Added a unit test to test that the desired behavior was correct. The test:
1. Puts nonsense data in the session.
2. Sends a request to `"/cs/search-results/page1"`.
3. Asserts that the status code is 200 instead of a failed request, and that the card search button is present, indicating that the user is now at the home page.

**NOTE:** To run this test, please run `python3 -m unittest discover -s tests` from the root of the project.

Tested manually in browser:

https://github.com/honlnm/Capstone-1---MTGWorkshop/assets/40155298/092244fb-0428-4e12-b780-8765c5e696eb

